### PR TITLE
Mark switch to `JumpDuration` value type for spawn init data

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #include "main.hpp"
 
 #include "GlobalNamespace/BeatmapDataTransformHelper.hpp"
+#include "GlobalNamespace/BeatmapObjectSpawnControllerHelpers.hpp"
 #include "GlobalNamespace/BeatmapObjectSpawnMovementData.hpp"
 #include "GlobalNamespace/EnvironmentEffectsFilterPreset.hpp"
 #include "GlobalNamespace/GameplayCoreSceneSetupData.hpp"
@@ -83,6 +84,22 @@ MAKE_HOOK_MATCH(
     BeatmapObjectSpawnMovementData_Init(
         self, noteLinesCount, startNoteJumpMovementSpeed, startBpm, noteJumpValueType, noteJumpValue, jumpOffsetYProvider, rightVec, forwardVec
     );
+}
+
+MAKE_HOOK_MATCH(
+    BeatmapObjectSpawnControllerHelpers_GetNoteJumpValues,
+    &BeatmapObjectSpawnControllerHelpers::GetNoteJumpValues,
+    void,
+    ::GlobalNamespace::PlayerSpecificSettings* playerSpecificSettings,
+    float_t defaultNoteJumpStartBeatOffset,
+    ByRef<::GlobalNamespace::__BeatmapObjectSpawnMovementData__NoteJumpValueType> noteJumpValueType,
+    ByRef<float_t> noteJumpValue
+) {
+    BeatmapObjectSpawnControllerHelpers_GetNoteJumpValues(playerSpecificSettings, defaultNoteJumpStartBeatOffset, noteJumpValueType, noteJumpValue);
+
+    if (!getModConfig().Disable.GetValue()) {
+        *noteJumpValueType = BeatmapObjectSpawnMovementData::NoteJumpValueType::JumpDuration;
+    }
 }
 
 MAKE_HOOK_MATCH(StandardLevelDetailView_RefreshContent, &StandardLevelDetailView::RefreshContent, void, StandardLevelDetailView* self) {
@@ -187,6 +204,7 @@ extern "C" void load() {
 
     // Install hooks
     INSTALL_HOOK(logger, BeatmapObjectSpawnMovementData_Init);
+    INSTALL_HOOK(logger, BeatmapObjectSpawnControllerHelpers_GetNoteJumpValues);
     INSTALL_HOOK(logger, StandardLevelDetailView_RefreshContent);
     INSTALL_HOOK(logger, LevelParamsPanel_set_notesPerSecond);
     INSTALL_HOOK(logger, LevelScenesTransitionSetupDataSO_BeforeScenesWillBeActivatedAsync);


### PR DESCRIPTION
JDFixer forces `SpawnMovementData` to `JumpDuration` value type. This leads to issues with other mods that calculate JD, as value from `GetNoteJumpValues` and `BeatmapObjectSpawnController::InitData` remain from the system settings.

Map to test: https://beatleader.xyz/leaderboard/global/3973677
Switch in player settings to the time offset type (by default, "Further", "Closer", etc... one.) JD for custom notes is broken without this patch.